### PR TITLE
Make sponsor list an actual list

### DIFF
--- a/_includes/sponsors.njk
+++ b/_includes/sponsors.njk
@@ -1,8 +1,8 @@
 <section>
   <h2>We are working with</h2>
-  <div id="sponsors">
+  <ul id="sponsors" aria-role="list">
     {% for sponsor in sponsors %}
-    {{ sponsor | formatSponsorLogo | safe }}
+    <li>{{ sponsor | formatSponsorLogo | safe }}</li>
     {% endfor %}
-  </div>
+  </ul>
 </section>

--- a/assets/main.css
+++ b/assets/main.css
@@ -105,6 +105,14 @@ h2 {
   margin: auto;
 }
 
+#sponsors li {
+  list-style-type: none; /* remove bullets */
+}
+
+#sponsors li::before {
+  content: "\200B"; /* add zero-width space */
+}
+
 #sponsors img {
   max-width: 150px;
   width: 100%;


### PR DESCRIPTION
Previously our sponsor grid was a div with anchors. To improve accessibility, I changed the div into unordered list, added a list item tag around the links and hid the bullets from list items based on [VoiceOver and list-style-type: none | Writing | gerardkcohen.me](https://gerardkcohen.me/writing/2017/voiceover-list-style-type.html).