### PR TITLE
Temporarily hide instructions for Slack

### DIFF
--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -37,7 +37,7 @@
       </svg>
     </a>
   </span>
-  <span>
+  <!-- <span>
     <a href="https://turkufrontend.fly.dev">
       <span class="sr-only">Turku &hearts; Frontend Slack</span>
       <svg
@@ -56,7 +56,7 @@
         </g>
       </svg>
     </a>
-  </span>
+  </span> -->
   <span>
     <!-- Medium icon by Icons8 -->
     <a href="https://medium.com/@turkufrontend">

--- a/_includes/introduction.njk
+++ b/_includes/introduction.njk
@@ -12,12 +12,12 @@
       >register at Meetabit</a
     >.
   </p>
-  <p>
+  <!--<p>
     We also have a
     <a href="https://turkufrontend.fly.dev/" target="_blank">Slack group</a> you
     can join to stay in touch with fellow developers between our events and to
     be amongst the first to hear about new activities.
-  </p>
+  </p>-->
   <p>
     Our meetups would not be possible without
     <a href="{{ '/hall-of-fame' | url }}"> our amazing speakers </a>so thank you


### PR DESCRIPTION
I had to turn off the self-invite system for Slack.

We received a ton of spam-ish registrations to emails that all bounced.

This also started racking up the bill for the first time for this account, so I decided to shut it down for now.

When I have time to look into it, I'll turn it back on.